### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Visto que o .DS_Store é um arquivo padrão de um sistema operacional, ele pode ser colocado no .gitignore.